### PR TITLE
Disables 'media library' and 'signature' in Webform allowed inputs

### DIFF
--- a/boulder_d11_profile.info.yml
+++ b/boulder_d11_profile.info.yml
@@ -87,7 +87,6 @@ install:
   - ucb_user_invite
   - ucb_focal_image_enable
   - ucb_bootstrap_layouts
-  - media_library_form_element
   - media_alias_display
   - media_entity_file_replace
   - entity_usage

--- a/config/install/webform.settings.yml
+++ b/config/install/webform.settings.yml
@@ -156,6 +156,7 @@ element:
   excluded_elements:
     password: password
     password_confirm: password_confirm
+    webform_signature: webform_signature
 html_editor:
   disabled: false
   element_format: wysiwyg


### PR DESCRIPTION
Removes the signature and uninstalls the optional Media Library Input module (media_library_form_element) to disable the two insecure inputs

Resolves https://github.com/CuBoulder/tiamat10-profile/issues/300